### PR TITLE
Added command as a single line to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ docker \
         hmsccb/nhanes-workbench:version-0.4.0
 ```
 
+If you're using windows you may need to give the command as a single line:
+
+```
+docker run --rm --platform=linux/amd64 --name nhanes-workbench  -d -v LOCAL_DIRECTORY:/HostData -p 8787:8787 -p 2200:22 -p 1433:1433 -e 'CONTAINER_USER_USERNAME=USER' -e 'CONTAINER_USER_PASSWORD=PASSWORD' -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=yourStrong(!)Password' hmsccb/nhanes-workbench:version-0.4.0
+```
 For other versions, see the [Dockerhub repository](https://hub.docker.com/r/hmsccb/nhanes-workbench/tags) and use the desired tag.
 
 ### Parameters


### PR DESCRIPTION
Some folks using windows weren't able to copy-paste the run command since the backslash new-lines don't work on Windows. Adding the run command as a single line will help smooth things for those users. 